### PR TITLE
Custom tribute message 2

### DIFF
--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -730,45 +730,44 @@ string Government::GetPlanetBribeRejectionHail() const
 
 
 
-string Government::GetTributeAlreadyPaying() const
+const Phrase *Government::TributeAlreadyPaying() const
 {
-	return tributeAlreadyPaying ? tributeAlreadyPaying->Get() : "We are already paying you as much as we can afford.";
+	return tributeAlreadyPaying;
 }
 
 
 
-string Government::GetTributeUndefined() const
+const Phrase *Government::TributeUndefined() const
 {
-	return tributeUndefined ? tributeUndefined->Get() : "Please don't joke about that sort of thing.";
+	return tributeUndefined;
 }
 
 
 
-string Government::GetTributeUnworthy() const
+const Phrase *Government::TributeUnworthy() const
 {
-	return tributeUnworthy ? tributeUnworthy->Get() : "You're not worthy of our time.";
+	return tributeUnworthy;
 }
 
 
 
-string Government::GetTributeFleetLaunching() const
+const Phrase *Government::TributeFleetLaunching() const
 {
-	return tributeFleetLaunching ? tributeFleetLaunching->Get() : "Our defense fleet will make short work of you.";
+	return tributeFleetLaunching;
 }
 
 
 
-string Government::GetTributeFleetUndefeated() const
+const Phrase *Government::TributeFleetUndefeated() const
 {
-	return tributeFleetUndefeated ? tributeFleetUndefeated->Get() : "We're not ready to surrender yet.";
+	return tributeFleetUndefeated;
 }
 
 
 
-string Government::GetTributeSurrendered() const
+const Phrase *Government::TributeSurrendered() const
 {
-	return tributeSurrendered ? tributeSurrendered->Get() : "We surrender. We will pay you "
-		"<credits> per day to leave us alone.";
+	return tributeSurrendered;
 }
 
 

--- a/source/Government.h
+++ b/source/Government.h
@@ -126,12 +126,12 @@ public:
 	std::string GetPlanetBribeRejectionHail() const;
 
 	// Get the messages that the governmend responds with when speaking about tribute.
-	std::string GetTributeAlreadyPaying() const;
-	std::string GetTributeUndefined() const;
-	std::string GetTributeUnworthy() const;
-	std::string GetTributeFleetLaunching() const;
-	std::string GetTributeFleetUndefeated() const;
-	std::string GetTributeSurrendered() const;
+	const Phrase *TributeAlreadyPaying() const;
+	const Phrase *TributeUndefined() const;
+	const Phrase *TributeUnworthy() const;
+	const Phrase *TributeFleetLaunching() const;
+	const Phrase *TributeFleetUndefeated() const;
+	const Phrase *TributeSurrendered() const;
 
 	// Find out if this government speaks a different language.
 	const std::string &Language() const;

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -137,6 +137,15 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes, const Conditio
 				defenseFleets.clear();
 				ResetDefense();
 			}
+			else if(key == "tribute hails")
+			{
+				tributeAlreadyPaying = nullptr;
+				tributeUndefined = nullptr;
+				tributeUnworthy = nullptr;
+				tributeFleetUndefeated = nullptr;
+				tributeFleetLaunching = nullptr;
+				tributeSurrendered = nullptr;
+			}
 			else if(key == "wormhole")
 				wormhole = nullptr;
 			else if(key == "to")

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -268,6 +268,33 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes, const Conditio
 					grand.PrintTrace("Skipping unrecognized tribute attribute:");
 			}
 		}
+		else if(key == "tribute hails" && child.HasChildren())
+		{
+			for(const DataNode &grand : child)
+			{
+				if(grand.Size() != 2)
+				{
+					grand.PrintTrace("Skipping unrecognized attribute:");
+					continue;
+				}
+				bool removeTributePhrase = grand.Token(0) == "remove";
+				const string &grandKey = grand.Token(remove);
+				if(grandKey == "already paying")
+					tributeAlreadyPaying = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "undefined")
+					tributeUndefined = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "unworthy")
+					tributeUnworthy = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "fleet launching")
+					tributeFleetLaunching = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "fleet undefeated")
+					tributeFleetUndefeated = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "surrendered")
+					tributeSurrendered = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else
+					grand.PrintTrace("Skipping unrecognized attribute:");
+			}
+		}
 		else if(key == "wormhole")
 		{
 			wormhole = wormholes.Get(value);

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -804,11 +804,29 @@ string Planet::DemandTribute(PlayerInfo &player) const
 		return "Somehow, this planet does not have a government.";
 	const auto &playerTribute = player.GetTribute();
 	if(playerTribute.find(this) != playerTribute.end())
-		return government->GetTributeAlreadyPaying();
+	{
+		if(tributeAlreadyPaying)
+			return tributeAlreadyPaying->Get();
+		else if(government && government->TributeAlreadyPaying())
+			return government->TributeAlreadyPaying()->Get();
+		return "We are already paying you as much as we can afford.";
+	}
 	if(!tribute || defenseFleets.empty())
-		return government->GetTributeUndefined();
+	{
+		if(tributeUndefined)
+			return tributeUndefined->Get();
+		else if(government && government->TributeUndefined())
+			return government->TributeUndefined()->Get();
+		return "Please don't joke about that sort of thing.";
+	}
 	if(player.Conditions().Get("combat rating") < defenseThreshold)
-		return government->GetTributeUnworthy();
+	{
+		if(tributeUnworthy)
+			return tributeUnworthy->Get();
+		else if(government && government->TributeUnworthy())
+			return government->TributeUnworthy()->Get();
+		return "You're not worthy of our time.";
+	}
 
 	// The player is scary enough for this planet to take notice. Check whether
 	// this is the first demand for tribute, or not.
@@ -826,7 +844,11 @@ string Planet::DemandTribute(PlayerInfo &player) const
 		// expose syntax for controlling its impact on the targeted government
 		// and those that know it.
 		GetGovernment()->Offend(ShipEvent::ATROCITY);
-		return government->GetTributeFleetLaunching();
+		if(tributeFleetLaunching)
+			return tributeFleetLaunching->Get();
+		else if(government && government->TributeFleetLaunching())
+			return government->TributeFleetLaunching()->Get();
+		return "Our defense fleet will make short work of you.";
 	}
 
 	// The player has already demanded tribute. Have they defeated the entire defense fleet?
@@ -839,12 +861,23 @@ string Planet::DemandTribute(PlayerInfo &player) const
 		}
 
 	if(!isDefeated)
-		return government->GetTributeFleetUndefeated();
+	{
+		if(tributeFleetUndefeated)
+			return tributeFleetUndefeated->Get();
+		else if(government && government->TributeFleetUndefeated())
+			return government->TributeFleetUndefeated()->Get();
+		return "We're not ready to surrender yet.";
+	}
 
 	player.SetTribute(this, tribute);
-	string surrenderedMessage = government->GetTributeSurrendered();
-	surrenderedMessage = Format::Replace(surrenderedMessage, {{"<credits>", Format::CreditString(tribute)}});
-	return surrenderedMessage;
+	string surrenderMessage;
+	if(tributeSurrendered)
+		surrenderMessage = tributeSurrendered->Get();
+	else if(government && government->TributeSurrendered())
+		surrenderMessage = government->TributeSurrendered()->Get();
+	else
+		surrenderMessage = "We surrender. We will pay you <credits> per day to leave us alone.";
+	return Format::Replace(surrenderMessage, {{"<credits>", Format::CreditString(tribute)}});
 }
 
 

--- a/source/Planet.h
+++ b/source/Planet.h
@@ -31,6 +31,7 @@ class DataNode;
 class Fleet;
 class Government;
 class Outfit;
+class Phrase;
 class PlayerInfo;
 class Ship;
 class Sprite;
@@ -219,6 +220,13 @@ private:
 	mutable size_t defenseDeployed = 0;
 	// Ships that have been created by instantiating its defense fleets.
 	mutable std::list<std::shared_ptr<Ship>> defenders;
+
+	const Phrase *tributeAlreadyPaying = nullptr;
+	const Phrase *tributeUndefined = nullptr;
+	const Phrase *tributeUnworthy = nullptr;
+	const Phrase *tributeFleetLaunching = nullptr;
+	const Phrase *tributeFleetUndefeated = nullptr;
+	const Phrase *tributeSurrendered = nullptr;
 
 	Wormhole *wormhole = nullptr;
 	std::vector<const System *> systems;


### PR DESCRIPTION
Since Planet needs to check if it has its own phrases first before asking for what the Government has, I'd prefer to leave the default strings in Planet::DemandTribute.